### PR TITLE
early check for initdb

### DIFF
--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -441,7 +441,6 @@ static void findInitDB(const char *argv0)
 static void
 syncDataDir(char *DataDir)
 {
-	int			ret;
 	char		cmd[MAXCMDLEN];
 
 

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -601,7 +601,8 @@ main(int argc, char *argv[])
 	if (activate || verify)
 #if PG_VERSION_NUM < 100000
 		// check for initdb
-		findInitDB(argv[0]);
+		if (activate)
+			findInitDB(argv[0]);
 #endif
 	{
 		/* Scan all files */

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -398,7 +398,7 @@ updateControlFile(char *DataDir, ControlFileData *ControlFile)
 }
 
 /*
- * syncDataDir() is used on PostgreSQL releases <= 10, only
+ * syncDataDir() and findInitDB are used on PostgreSQL releases < 10, only
  */
 #if PG_VERSION_NUM < 100000
 


### PR DESCRIPTION
if pg_checksums was not installed in the same path as initdb,
we would error out AFTER creating all checksums in the datafiles

Now, we check for initdb, if needed, before scanning all files