### PR TITLE
Block retry for online checksum verification

### DIFF
--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -158,6 +158,14 @@ scan_file(char *fn, int segmentno)
 
 		if (r != BLCKSZ)
 		{
+			if (block_retry)
+			{
+				/* We already tried once to reread the block, bail out */
+				fprintf(stderr, _("%s: short read of block %d in file \"%s\", got only %d bytes\n"),
+								progname, blockno, fn, r);
+				exit(1);
+			}
+
 			if (debug)
 				fprintf(stderr, _("%s: short read of block %d in file \"%s\", got only %d bytes\n"),
 						progname, blockno, fn, r);

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -147,12 +147,13 @@ scan_file(char *fn, int segmentno)
 
 		if (debug && block_retry)
 			fprintf(stderr, _("%s: retrying block %d in file \"%s\"\n"),
-                                        progname, blockno, fn);
+					progname, blockno, fn);
 
 		if (r == 0)
 		{
 			if (debug && block_retry)
-				fprintf(stderr, _("%s: block %d in file \"%s\" is EOF, ignoring\n"), progname, blockno, fn);
+				fprintf(stderr, _("%s: block %d in file \"%s\" is EOF, ignoring\n"),
+						progname, blockno, fn);
 			break;
 		}
 
@@ -162,7 +163,7 @@ scan_file(char *fn, int segmentno)
 			{
 				/* We already tried once to reread the block, bail out */
 				fprintf(stderr, _("%s: short read of block %d in file \"%s\", got only %d bytes\n"),
-								progname, blockno, fn, r);
+						progname, blockno, fn, r);
 				exit(1);
 			}
 
@@ -186,7 +187,8 @@ scan_file(char *fn, int segmentno)
 			 */
 			if (lseek(f, -r, SEEK_CUR) == -1)
 			{
-				fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"), progname, fn);
+				fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"),
+						progname, fn);
 				exit(1);
 			}
 
@@ -232,7 +234,8 @@ scan_file(char *fn, int segmentno)
 					/* Seek to the beginning of the failed block */
 					if (lseek(f, -BLCKSZ, SEEK_CUR) == -1)
 					{
-						fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"), progname, fn);
+						fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"),
+								progname, fn);
 						exit(1);
 					}
 
@@ -254,12 +257,9 @@ scan_file(char *fn, int segmentno)
 							progname, fn, blockno, csum, header->pd_checksum);
 				badblocks++;
 			}
-			else
-			{
-				if (block_retry)
+			else if (block_retry)
 					fprintf(stderr, _("%s: block %d in file \"%s\" verified ok on recheck\n"),
 							progname, blockno, fn);
-			}
 
 			block_retry = false;
 		}
@@ -287,7 +287,6 @@ scan_file(char *fn, int segmentno)
 				exit(1);
 			}
 		}
-
 	}
 
 	close(f);

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -177,7 +177,10 @@ scan_file(char *fn, int segmentno)
 			 * beginning of the failed block
 			 */
 			if (lseek(f, -r, SEEK_CUR) == -1)
+			{
 				fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"), progname, fn);
+				exit(1);
+			}
 
 			/* Set flag so we know a retry was attempted */
 			block_retry = true;
@@ -220,7 +223,10 @@ scan_file(char *fn, int segmentno)
 
 					/* Seek to the beginning of the failed block */
 					if (lseek(f, -BLCKSZ, SEEK_CUR) == -1)
+					{
 						fprintf(stderr, _("%s: could not lseek in file \"%s\": %m\n"), progname, fn);
+						exit(1);
+					}
 
 					/* Set flag so we know a retry was attempted */
 					block_retry = true;

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -679,6 +679,10 @@ main(int argc, char *argv[])
 	ControlFile = getControlFile(DataDir);
 #endif
 
+	/*
+	 * Cluster must be shut down for activation/deactivation of checksums,
+	 * but online verification is supported.
+	 */
 	if (ControlFile->state != DB_SHUTDOWNED &&
 		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY &&
 		!verify)

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -165,7 +165,6 @@ scan_file(char *fn, int segmentno)
 			if (csum != header->pd_checksum)
 			{
 				/*
-
 				 * Retry the block on the first failure.  It's
 				 * possible that we read the first 4K page of
 				 * the block just before postgres updated the

--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -258,8 +258,8 @@ scan_file(char *fn, int segmentno)
 				badblocks++;
 			}
 			else if (block_retry)
-					fprintf(stderr, _("%s: block %d in file \"%s\" verified ok on recheck\n"),
-							progname, blockno, fn);
+				fprintf(stderr, _("%s: block %d in file \"%s\" verified ok on recheck\n"),
+						progname, blockno, fn);
 
 			block_retry = false;
 		}

--- a/t/001_checksums.pl
+++ b/t/001_checksums.pl
@@ -24,8 +24,8 @@ my $pgdata = $node->data_dir;
 $node->command_fails(['pg_checksums', '-c'],
         'pg_checksums needs needs target directory specified');
 
-$node->command_fails(['pg_checksums', '-c', '-D', $pgdata],
-        'pg_checksums needs to run against offfline cluster');
+$node->command_fails(['pg_checksums', '-a', '-D', $pgdata],
+        'pg_checksums -a needs to run against offfline cluster');
 
 my $checksum = $node->safe_psql('postgres', 'SHOW data_checksums;');
 is($checksum, 'off', 'checksums are disabled');

--- a/t/001_checksums.pl
+++ b/t/001_checksums.pl
@@ -6,7 +6,7 @@ use Cwd;
 use Config;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 19;
+use Test::More tests => 20;
 
 program_help_ok('pg_checksums');
 program_version_ok('pg_checksums');
@@ -56,6 +56,9 @@ $node->command_ok(['pg_checksums', '-a', '-D', $pgdata],
         'pg_checksums are again activated in offline cluster');
 
 $node->start;
+
+$node->command_ok(['pg_checksums', '-c', '-D', $pgdata],
+        'pg_checksums can be verified in online cluster');
 
 # create table to corrupt and get their relfilenode
 my $file_corrupt = $node->safe_psql('postgres',


### PR DESCRIPTION
Right now, `pg_checksums` needs to run against an offline cluster. However, the base backup checksum verification feature in v11 is able to run against an online cluster. It does recheck the block on the first checksum failure on the assumption that we might read a torn/half page. I have ported this code to `pg_checkums` and removed the 'must be offline' check for the verification mode. I also had to add `pgsql_tmp` to the skiplist, as those can be created during online verification and would result in spurious checksum failures.

In addition to the retry on checksum failure, I also added (one) retry on short read - testing with `pgbench -s` turned up sporadic but reproducible short reads like `pg_checksums: short read of block 6602 in file "data1/base/12375/17060", got only 4096 bytes`, likely via autovacuum shrink. Probably this needs to be investigated in PostgreSQL proper as well. We bail out with error for now on a repeated short read, in order to avoid endless loops.

As we read only in `BLCKSZ` chunks, we do not need the more involved retry logic from PostgreSQL's `basebackup.c`, where we have to re-read the particular block of a larger buffer.

FInally, testing with `pgbench -s` also turned up some spurious `pg_checksums: could not stat file "data1/base/12375/16467_vm"` failures that are race conditions between `readdir()` and `stat()`. If the errno is `ENOENT`, we ignore `stat()` failures as verifying checksums of already removed files makes no sense.

One new TAP test that simply checks whether online verification succeeds.