### PR TITLE
Incorrect offline verification logic

### DIFF
--- a/pg_checksums.c
+++ b/pg_checksums.c
@@ -378,7 +378,7 @@ scan_file(const char *fn, BlockNumber segmentno)
 				 * the page has been modified since the checkpoint and skip it
 				 * in this case.
 				 */
-				if (PageGetLSN(buf.data) > checkpointLSN)
+				if (online && PageGetLSN(buf.data) > checkpointLSN)
 				{
 					if (debug)
 						fprintf(stderr, _("%s: block %d in file \"%s\" with LSN %X/%X is newer than checkpoint LSN %X/%X, ignoring\n"),
@@ -880,14 +880,13 @@ main(int argc, char *argv[])
 	 * online verification is supported.
 	 */
 	if (ControlFile->state != DB_SHUTDOWNED &&
-		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY &&
-		!verify)
+		ControlFile->state != DB_SHUTDOWNED_IN_RECOVERY)
 	{
-		fprintf(stderr, _("%s: cluster must be shut down\n"), progname);
-		exit(1);
-	}
-	else
-	{
+		if (!verify)
+		{
+			fprintf(stderr, _("%s: cluster must be shut down\n"), progname);
+			exit(1);
+		}
 		online = true;
 	}
 


### PR DESCRIPTION
Hello
I found unexpected behavior during offline checksum verification.

Reproduce: manually replace some block with garbage
`dd if=/dev/urandom bs=8K count=1 seek=80K of=10/replica/base/13031/24582`
Verify database:
```/usr/lib/postgresql/10/bin/pg_checksums -D 10/replica/ -c
Checksum scan completed
Files scanned:  932
Blocks scanned: 47128
Blocks skipped: 37673
Bad checksums:  0
Data checksum version: 1
```

Tool say all its ok, but many pages was skipped (it can be ok due PageIsNew, for example). Error is visible in debug output:

```pg_checksums: checksum verification failed on first attempt in file "10/replica//base/13031/24582", block 81920: calculated checksum 6666 but block contains 4380
pg_checksums: retrying block 81920 in file "10/replica//base/13031/24582"
pg_checksums: block 81920 in file "10/replica//base/13031/24582" with LSN A5B72E0F/8D11B6EC is newer than checkpoint LSN 1/525B8938, ignoring
```

We found error, but assume this is concurrent write by online DB. This can not be true in case stopped database and tool may silently ignore checksum error.

Also i think here is error in `ControlFile->state != DB_SHUTDOWNED` logic, we always assume `online = true` for verify scan.

regards, Sergei