### PR TITLE
Rename program to pg_checksums_ext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 #-------------------------------------------------------------------------
 #
-# Makefile for pg_checksums
+# Makefile for pg_checksums_ext
 #
 # Copyright (c) 1998-2019, PostgreSQL Global Development Group
 #
-# pg_checksums/Makefile
+# pg_checksums_ext/Makefile
 #
 #-------------------------------------------------------------------------
 
-PROGRAM = pg_checksums
-PGFILEDESC = "pg_checksums - Activate/deactivate/verify data checksums in an offline cluster"
+PROGRAM = pg_checksums_ext
+PGFILEDESC = "pg_checksums_ext - Checks, enables or disables page level checksums for a cluster"
 PGAPPICON=win32
 
-OBJS= pg_checksums.o port.o $(WIN32RES)
+OBJS= pg_checksums_ext.o port.o $(WIN32RES)
 EXTRA_CLEAN = tmp_check doc/man1
 
 PG_CONFIG ?= pg_config
@@ -24,11 +24,11 @@ LIBS = $(libpq_pgport)
 
 PROVE_FLAGS += -I./t/perl
 
-all: pg_checksums
+all: pg_checksums_ext
 
-man: doc/man1/pg_checksums.1
+man: doc/man1/pg_checksums_ext.1
 
-doc/man1/pg_checksums.1: doc/pg_checksums.sgml
+doc/man1/pg_checksums_ext.1: doc/pg_checksums.sgml
 	(cd doc && xsltproc stylesheet-man.xsl pg_checksums.sgml)
 
 prove_installcheck:

--- a/doc/pg_checksums.sgml
+++ b/doc/pg_checksums.sgml
@@ -9,19 +9,19 @@ PostgreSQL documentation
  </indexterm>
 
  <refmeta>
-  <refentrytitle><application>pg_checksums</application></refentrytitle>
+  <refentrytitle><application>pg_checksums_ext</application></refentrytitle>
   <manvolnum>1</manvolnum>
   <refmiscinfo>Application</refmiscinfo>
  </refmeta>
 
  <refnamediv>
-  <refname>pg_checksums</refname>
+  <refname>pg_checksums_ext</refname>
   <refpurpose>enable, disable or check data checksums in a <productname>PostgreSQL</productname> database cluster</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>pg_checksums</command>
+   <command>pg_checksums_ext</command>
    <arg rep="repeat" choice="opt"><replaceable class="parameter">option</replaceable></arg>
    <group choice="opt">
     <group choice="opt">
@@ -33,10 +33,10 @@ PostgreSQL documentation
   </cmdsynopsis>
  </refsynopsisdiv>
 
- <refsect1 id="r1-app-pg_checksums-1">
+ <refsect1 id="r1-app-pg_checksums_ext-1">
   <title>Description</title>
   <para>
-   <application>pg_checksums</application> checks, enables or disables data
+   <application>pg_checksums_ext</application> checks, enables or disables data
    checksums in a <productname>PostgreSQL</productname> cluster.  The server
    must be shut down when enabling or disabling checksums, while verifying
    checksums can be done online. When verifying checksums, the exit
@@ -117,9 +117,9 @@ PostgreSQL documentation
       <term><option>--no-sync</option></term>
       <listitem>
        <para>
-        By default, <command>pg_checksums</command> will wait for all files
+        By default, <command>pg_checksums_ext</command> will wait for all files
         to be written safely to disk.  This option causes
-        <command>pg_checksums</command> to return without waiting, which is
+        <command>pg_checksums_ext</command> to return without waiting, which is
         faster, but means that a subsequent operating system crash can leave
         the updated data directory corrupt.  Generally, this option is useful
         for testing but should not be used on a production installation.
@@ -173,7 +173,7 @@ PostgreSQL documentation
        <term><option>--version</option></term>
        <listitem>
        <para>
-        Print the <application>pg_checksums</application> version and exit.
+        Print the <application>pg_checksums_ext</application> version and exit.
        </para>
        </listitem>
      </varlistentry>
@@ -183,7 +183,7 @@ PostgreSQL documentation
       <term><option>--help</option></term>
        <listitem>
         <para>
-         Show help about <application>pg_checksums</application> command line
+         Show help about <application>pg_checksums_ext</application> command line
          arguments, and exit.
         </para>
        </listitem>
@@ -239,9 +239,9 @@ PostgreSQL documentation
    safe.
   </para>
   <para>
-   If <application>pg_checksums</application> is aborted or killed while
+   If <application>pg_checksums_ext</application> is aborted or killed while
    enabling or disabling checksums, the cluster's data checksum configuration
-   remains unchanged, and <application>pg_checksums</application> can be
+   remains unchanged, and <application>pg_checksums_ext</application> can be
    re-run to perform the same operation.
   </para>
  </refsect1>

--- a/pg_checksums_ext.c
+++ b/pg_checksums_ext.c
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
  *
- * pg_checksums.c
+ * pg_checksums_ext.c
  *	  Checks, enables or disables page level checksums for a cluster
  *
  * Copyright (c) 2010-2022, PostgreSQL Global Development Group
  *
  * IDENTIFICATION
- *	  pg_checksums.c
+ *	  pg_checksums_ext.c
  *
  *-------------------------------------------------------------------------
  */
@@ -751,7 +751,7 @@ main(int argc, char *argv[])
 #endif
 
 	pg_logging_init(argv[0]);
-	set_pglocale_pgservice(argv[0], PG_TEXTDOMAIN("pg_checksums"));
+	set_pglocale_pgservice(argv[0], PG_TEXTDOMAIN("pg_checksums_ext"));
 	progname = get_progname(argv[0]);
 
 	if (argc > 1)
@@ -763,7 +763,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_checksums " PG_CHECKSUMS_VERSION " (PostgreSQL " PG_MAJORVERSION ")");
+			puts("pg_checksums_ext " PG_CHECKSUMS_VERSION " (PostgreSQL " PG_MAJORVERSION ")");
 			exit(0);
 		}
 	}
@@ -884,14 +884,14 @@ main(int argc, char *argv[])
 
 	if (ControlFile->pg_control_version != PG_CONTROL_VERSION)
 	{
-		pg_log_error("cluster is not compatible with this version of pg_checksums");
+		pg_log_error("cluster is not compatible with this version of pg_checksums_ext");
 		exit(1);
 	}
 
 	if (ControlFile->blcksz != BLCKSZ)
 	{
 		pg_log_error("database cluster is not compatible");
-		fprintf(stderr, _("The database cluster was initialized with block size %u, but pg_checksums was compiled with block size %u.\n"),
+		fprintf(stderr, _("The database cluster was initialized with block size %u, but pg_checksums_ext was compiled with block size %u.\n"),
 				ControlFile->blcksz, BLCKSZ);
 		exit(1);
 	}


### PR DESCRIPTION
This makes it easy to distinguish pg_checksums_ext(ernal) from the upstream
pg_checksums program and allows side-by-side installation of both in the same
binary directory without one overwriting the other or having to divert
binaries.