### PR TITLE
Two fixes for PostgreSQL 19

### DIFF
--- a/pg_checksums_ext.c
+++ b/pg_checksums_ext.c
@@ -151,8 +151,9 @@ update_checkpoint_lsn(void)
 }
 
 static void
-toggle_progress_report(int signum)
+toggle_progress_report(SIGNAL_ARGS)
 {
+	int			signum = postgres_signal_arg;
 
 	/* we handle SIGUSR1 only, and toggle the value of showprogress */
 	if (signum == SIGUSR1)
@@ -739,6 +740,9 @@ main(int argc, char *argv[])
 	bool		crc_ok;
 
 	pg_logging_init(argv[0]);
+#if PG_VERSION_NUM >= 190000
+	pg_initialize_timing();
+#endif
 	set_pglocale_pgservice(argv[0], PG_TEXTDOMAIN("pg_checksums_ext"));
 	progname = get_progname(argv[0]);
 


### PR DESCRIPTION
* PostgreSQL 19 changed the pqsigfunc typedef to use SIGNAL_ARGS instead of a plain (int) parameter.  SIGNAL_ARGS expands to:

    int, const struct pg_signal_info *

on POSIX platforms (port.h commit b69bf30d upstream).  Passing a handler declared as void f(int) to pqsignal() is therefore an incompatible function pointer conversion that is an error under -Wincompatible-function-pointer-types (Clang) /
-Wincompatible-pointer-types (GCC -Werror).

Replace the explicit (int signum) parameter with the SIGNAL_ARGS macro and recover the signal number via the postgres_signal_arg convenience macro, which is the standard pattern used throughout the PostgreSQL source tree.

* PostgreSQL 19 introduced RDTSC-based high-resolution timing via a new instr_time.c translation unit.  All INSTR_TIME_SET_CURRENT() and INSTR_TIME_GET_*() macros now assert that timing_initialized is true before proceeding; without the initialisation call the tool aborts:

    pg_checksums_ext: instr_time.h:233: pg_get_ticks_system:
    Assertion `timing_initialized' failed.

The fix is to call pg_initialize_timing() (introduced in PG19) near the start of main(), after pg_logging_init() and before any timing macros can fire.  The call is guarded by PG_VERSION_NUM so the code continues to build against PG 14–18 unchanged.

Coded by Claude. Tested by me.